### PR TITLE
Critical error fix

### DIFF
--- a/src/net/mrfantivideo/morecrafting/Utils/ConfigUtils.java
+++ b/src/net/mrfantivideo/morecrafting/Utils/ConfigUtils.java
@@ -15,11 +15,11 @@ public class ConfigUtils
                     obj = Main.GetInstance().GetConfigSettings().GetConfiguration().get(path);
                 break;
             case MESSAGES:
-                if(Main.GetInstance().GetConfigSettings().GetConfiguration().contains(path))
+                if(Main.GetInstance().GetConfigMessages().GetConfiguration().contains(path))
                     obj = Main.GetInstance().GetConfigMessages().GetConfiguration().get(path);
                 break;
             case PERMISSIONS:
-                if(Main.GetInstance().GetConfigSettings().GetConfiguration().contains(path))
+                if(Main.GetInstance().GetConfigPermissions().GetConfiguration().contains(path))
                     obj = Main.GetInstance().GetConfigPermissions().GetConfiguration().get(path);
                 break;
         }


### PR DESCRIPTION
This commit fixes a critical mistake, which makes using this plugin impossible.
```
[14:24:50] [Server thread/ERROR]: Could not pass event PlayerInteractEvent to MoreCrafting v3.0
org.bukkit.event.EventException: null
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:320) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:529) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:514) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.craftbukkit.v1_14_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:429) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.craftbukkit.v1_14_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:396) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.craftbukkit.v1_14_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:392) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.PlayerConnection.a(PlayerConnection.java:1277) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:28) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:1) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.PlayerConnectionUtils.lambda$0(PlayerConnectionUtils.java:19) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.TickTask.run(SourceFile:18) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeTask(SourceFile:144) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeNext(SourceFile:118) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.MinecraftServer.aX(MinecraftServer.java:908) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.MinecraftServer.executeNext(MinecraftServer.java:901) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.awaitTasks(SourceFile:127) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.MinecraftServer.sleepForTick(MinecraftServer.java:885) [spigot.jar:git-Spigot-1981d55-860b354]
        at net.minecraft.server.v1_14_R1.MinecraftServer.run(MinecraftServer.java:818) [spigot.jar:git-Spigot-1981d55-860b354]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.lang.IllegalArgumentException: Permission name cannot be null
        at org.bukkit.permissions.PermissibleBase.hasPermission(PermissibleBase.java:73) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at org.bukkit.craftbukkit.v1_14_R1.entity.CraftHumanEntity.hasPermission(CraftHumanEntity.java:234) ~[spigot.jar:git-Spigot-1981d55-860b354]
        at net.mrfantivideo.morecrafting.Utils.PermissionsUtils.HasAnyPermission(PermissionsUtils.java:18) ~[?:?]
        at net.mrfantivideo.morecrafting.Listeners.PlayerInteractListener.OnPlayerInteract(PlayerInteractListener.java:36) ~[?:?]
        at sun.reflect.GeneratedMethodAccessor136.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_212]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_212]
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:316) ~[spigot.jar:git-Spigot-1981d55-860b354]
        ... 20 more
```